### PR TITLE
Add support for ESP8266

### DIFF
--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -44,8 +44,14 @@
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /**************************************************************************/
+#if defined(ESP8266)
+#include <pgmspace.h>
+#else
 #include <avr/pgmspace.h>
+#endif
+#if defined(__AVR__)
 #include <util/delay.h>
+#endif
 #include <stdlib.h>
 
 #include "Adafruit_TSL2591.h"


### PR DESCRIPTION
The TSL2591 has been verified to work on an ESP8266 HUZZAH board with
this change. Also a similar change is needed in Adafruit_Unified_Sensor.