### PR TITLE
make calculateLux return a float

### DIFF
--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -171,7 +171,7 @@ tsl2591IntegrationTime_t Adafruit_TSL2591::getTiming()
   return _integration;
 }
 
-uint32_t Adafruit_TSL2591::calculateLux(uint16_t ch0, uint16_t ch1)
+float Adafruit_TSL2591::calculateLux(uint16_t ch0, uint16_t ch1)
 {
   float    atime, again;
   float    cpl, lux1, lux2, lux;
@@ -242,7 +242,7 @@ uint32_t Adafruit_TSL2591::calculateLux(uint16_t ch0, uint16_t ch1)
   //lux = ( (float)ch0 - ( 1.7F * (float)ch1 ) ) / cpl;
 
   // Signal I2C had no errors
-  return (uint32_t)lux;
+  return lux;
 }
 
 uint32_t Adafruit_TSL2591::getFullLuminosity (void)

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -157,7 +157,7 @@ class Adafruit_TSL2591 : public Adafruit_Sensor
   uint16_t  read16  ( uint8_t reg );
   uint8_t   read8   ( uint8_t reg );
 
-  uint32_t  calculateLux  ( uint16_t ch0, uint16_t ch1 );
+  float  calculateLux  ( uint16_t ch0, uint16_t ch1 );
   void      setGain       ( tsl2591Gain_t gain );
   void      setTiming     ( tsl2591IntegrationTime_t integration );
   uint16_t  getLuminosity (uint8_t channel );

--- a/examples/tsl2591/tsl2591.ino
+++ b/examples/tsl2591/tsl2591.ino
@@ -152,7 +152,7 @@ void advancedRead(void)
   Serial.print("IR: "); Serial.print(ir);  Serial.print("  ");
   Serial.print("Full: "); Serial.print(full); Serial.print("  ");
   Serial.print("Visible: "); Serial.print(full - ir); Serial.print("  ");
-  Serial.print("Lux: "); Serial.println(tsl.calculateLux(full, ir));
+  Serial.print("Lux: "); Serial.println(tsl.calculateLux(full, ir), 6);
 }
 
 /**************************************************************************/


### PR DESCRIPTION
calculateLux is a ratio of VIS to IR channels with some constants thrown in.  All of the calculations are done in float, but the fractional component is thrown away at the end with a cast to uint32_t.  The TSL2591 is able to measure down to 188 uLux so let's make it return a float and change the example to print out some more decimals.