### PR TITLE
Added F() macro to all Serial.print()s

### DIFF
--- a/examples/tsl2591/tsl2591.ino
+++ b/examples/tsl2591/tsl2591.ino
@@ -25,15 +25,15 @@ void displaySensorDetails(void)
 {
   sensor_t sensor;
   tsl.getSensor(&sensor);
-  Serial.println("------------------------------------");
-  Serial.print  ("Sensor:       "); Serial.println(sensor.name);
-  Serial.print  ("Driver Ver:   "); Serial.println(sensor.version);
-  Serial.print  ("Unique ID:    "); Serial.println(sensor.sensor_id);
-  Serial.print  ("Max Value:    "); Serial.print(sensor.max_value); Serial.println(" lux");
-  Serial.print  ("Min Value:    "); Serial.print(sensor.min_value); Serial.println(" lux");
-  Serial.print  ("Resolution:   "); Serial.print(sensor.resolution); Serial.println(" lux");  
-  Serial.println("------------------------------------");
-  Serial.println("");
+  Serial.println(F("------------------------------------"));
+  Serial.print  (F("Sensor:       ")); Serial.println(sensor.name);
+  Serial.print  (F("Driver Ver:   ")); Serial.println(sensor.version);
+  Serial.print  (F("Unique ID:    ")); Serial.println(sensor.sensor_id);
+  Serial.print  (F("Max Value:    ")); Serial.print(sensor.max_value); Serial.println(F(" lux"));
+  Serial.print  (F("Min Value:    ")); Serial.print(sensor.min_value); Serial.println(F(" lux"));
+  Serial.print  (F("Resolution:   ")); Serial.print(sensor.resolution); Serial.println(F(" lux"));  
+  Serial.println(F("------------------------------------"));
+  Serial.println(F(""));
   delay(500);
 }
 
@@ -59,29 +59,29 @@ void configureSensor(void)
   // tsl.setTiming(TSL2591_INTEGRATIONTIME_600MS);  // longest integration time (dim light)
 
   /* Display the gain and integration time for reference sake */  
-  Serial.println("------------------------------------");
-  Serial.print  ("Gain:         ");
+  Serial.println(F("------------------------------------"));
+  Serial.print  (F("Gain:         "));
   tsl2591Gain_t gain = tsl.getGain();
   switch(gain)
   {
     case TSL2591_GAIN_LOW:
-      Serial.println("1x (Low)");
+      Serial.println(F("1x (Low)"));
       break;
     case TSL2591_GAIN_MED:
-      Serial.println("25x (Medium)");
+      Serial.println(F("25x (Medium)"));
       break;
     case TSL2591_GAIN_HIGH:
-      Serial.println("428x (High)");
+      Serial.println(F("428x (High)"));
       break;
     case TSL2591_GAIN_MAX:
-      Serial.println("9876x (Max)");
+      Serial.println(F("9876x (Max)"));
       break;
   }
-  Serial.print  ("Timing:       ");
+  Serial.print  (F("Timing:       "));
   Serial.print((tsl.getTiming() + 1) * 100, DEC); 
-  Serial.println(" ms");
-  Serial.println("------------------------------------");
-  Serial.println("");
+  Serial.println(F(" ms"));
+  Serial.println(F("------------------------------------"));
+  Serial.println(F(""));
 }
 
 
@@ -94,15 +94,15 @@ void setup(void)
 {
   Serial.begin(9600);
   
-  Serial.println("Starting Adafruit TSL2591 Test!");
+  Serial.println(F("Starting Adafruit TSL2591 Test!"));
   
   if (tsl.begin()) 
   {
-    Serial.println("Found a TSL2591 sensor");
+    Serial.println(F("Found a TSL2591 sensor"));
   } 
   else 
   {
-    Serial.println("No sensor found ... check your wiring?");
+    Serial.println(F("No sensor found ... check your wiring?"));
     while (1);
   }
     
@@ -130,8 +130,8 @@ void simpleRead(void)
   //uint16_t x = tsl.getLuminosity(TSL2591_FULLSPECTRUM);
   //uint16_t x = tsl.getLuminosity(TSL2591_INFRARED);
 
-  Serial.print("[ "); Serial.print(millis()); Serial.print(" ms ] ");
-  Serial.print("Luminosity: ");
+  Serial.print(F("[ ")); Serial.print(millis()); Serial.print(F(" ms ] "));
+  Serial.print(F("Luminosity: "));
   Serial.println(x, DEC);
 }
 
@@ -148,11 +148,11 @@ void advancedRead(void)
   uint16_t ir, full;
   ir = lum >> 16;
   full = lum & 0xFFFF;
-  Serial.print("[ "); Serial.print(millis()); Serial.print(" ms ] ");
-  Serial.print("IR: "); Serial.print(ir);  Serial.print("  ");
-  Serial.print("Full: "); Serial.print(full); Serial.print("  ");
-  Serial.print("Visible: "); Serial.print(full - ir); Serial.print("  ");
-  Serial.print("Lux: "); Serial.println(tsl.calculateLux(full, ir));
+  Serial.print(F("[ ")); Serial.print(millis()); Serial.print(F(" ms ] "));
+  Serial.print(F("IR: ")); Serial.print(ir);  Serial.print(F("  "));
+  Serial.print(F("Full: ")); Serial.print(full); Serial.print(F("  "));
+  Serial.print(F("Visible: ")); Serial.print(full - ir); Serial.print(F("  "));
+  Serial.print(F("Lux: ")); Serial.println(tsl.calculateLux(full, ir));
 }
 
 /**************************************************************************/
@@ -167,7 +167,7 @@ void unifiedSensorAPIRead(void)
   tsl.getEvent(&event);
  
   /* Display the results (light is measured in lux) */
-  Serial.print("[ "); Serial.print(event.timestamp); Serial.print(" ms ] ");
+  Serial.print(F("[ ")); Serial.print(event.timestamp); Serial.print(F(" ms ] "));
   if ((event.light == 0) |
       (event.light > 4294966000.0) | 
       (event.light <-4294966000.0))
@@ -175,11 +175,11 @@ void unifiedSensorAPIRead(void)
     /* If event.light = 0 lux the sensor is probably saturated */
     /* and no reliable data could be generated! */
     /* if event.light is +/- 4294967040 there was a float over/underflow */
-    Serial.println("Invalid data (adjust gain or timing)");
+    Serial.println(F("Invalid data (adjust gain or timing)"));
   }
   else
   {
-    Serial.print(event.light); Serial.println(" lux");
+    Serial.print(event.light); Serial.println(F(" lux"));
   }
 }
 


### PR DESCRIPTION
Reduced RAM footprint from 784 to 440 bytes.

The only change is to the Serial.print()s. Should have no impact on existing code. I'm suggesting the change because a user on freenode/#arduino was complaining the library was "too bloated to use." When in fact, the library is quite compact, it's the example that consumes so much RAM.
