### PR TITLE
add support for ESP32 (in the same way as for ESP8266)

### DIFF
--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -44,7 +44,7 @@
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /**************************************************************************/
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(ESP32)
 #include <pgmspace.h>
 #else
 #include <avr/pgmspace.h>


### PR DESCRIPTION
ESP32 has the same location for pgmspace.h as ESP8266; this patch simply checks for
the ESP32 preprocessor macro in the same place as the existing code checks for the ESP8266
macro, and does the same thing (include pgmspace.h instead of avr/pgmspace.h) if it is defined.