### PR TITLE
allow passing of specific SDA/SCL I2C pins to Wire begin via the TSL begin method

### DIFF
--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -66,9 +66,10 @@ Adafruit_TSL2591::Adafruit_TSL2591(int32_t sensorID)
   // we cant do wire initialization till later, because we havent loaded Wire yet
 }
 
-boolean Adafruit_TSL2591::begin(void)
+// initialise with specified Wire SDA / SCL pins (defaulting to -1)
+boolean Adafruit_TSL2591::begin( int sda, int scl )
 {
-  Wire.begin();
+  Wire.begin(sda, scl);
 
   /*
   for (uint8_t i=0; i<0x20; i++)

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -149,7 +149,7 @@ class Adafruit_TSL2591 : public Adafruit_Sensor
  public:
   Adafruit_TSL2591(int32_t sensorID = -1);
   
-  boolean   begin   ( void );
+  boolean   begin   ( int sda=-1, int scl=-1 );
   void      enable  ( void );
   void      disable ( void );
   void      write8  ( uint8_t r);


### PR DESCRIPTION
This change allows passing of the I2C pins through the TSL begin method. 
It is needed for boards that put I2C on non-default pins (e.g. Heltech ESP32 Lora).
It should be a backwards compatible (at source level).

