### PR TITLE
Continuous enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST

--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -65,6 +65,7 @@
 Adafruit_TSL2591::Adafruit_TSL2591(int32_t sensorID)
 {
   _initialized = false;
+  _enabled = false;
   _integration = TSL2591_INTEGRATIONTIME_100MS;
   _gain        = TSL2591_GAIN_MED;
   _sensorID    = sensorID;
@@ -105,6 +106,8 @@ boolean Adafruit_TSL2591::begin(void)
 
   // Note: by default, the device is in power down mode on bootup
   disable();
+  // you can enable it with
+  // enable();
 
   return true;
 }
@@ -127,6 +130,7 @@ void Adafruit_TSL2591::enable(void)
   // Enable the device by setting the control bit to 0x01
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_ENABLE,
 	 TSL2591_ENABLE_POWERON | TSL2591_ENABLE_AEN | TSL2591_ENABLE_AIEN | TSL2591_ENABLE_NPIEN);
+  _enabled = true;
 }
 
 
@@ -145,6 +149,7 @@ void Adafruit_TSL2591::disable(void)
 
   // Disable the device by setting the control bit to 0x00
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_ENABLE, TSL2591_ENABLE_POWEROFF);
+  _enabled = false;
 }
 
 /************************************************************************/
@@ -161,10 +166,15 @@ void Adafruit_TSL2591::setGain(tsl2591Gain_t gain)
     }
   }
 
-  enable();
+  boolean was_enabled = _enabled;
+  if (!_enabled) {
+    enable();
+  }
   _gain = gain;
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_CONTROL, _integration | _gain);
-  disable();
+  if (!was_enabled) {
+    disable();
+  }
 }
 
 /************************************************************************/
@@ -192,10 +202,15 @@ void Adafruit_TSL2591::setTiming(tsl2591IntegrationTime_t integration)
     }
   }
 
-  enable();
+  boolean was_enabled = _enabled;
+  if (!_enabled) {
+    enable();
+  }
   _integration = integration;
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_CONTROL, _integration | _gain);
-  disable();
+  if (!was_enabled) {
+    disable();
+  }
 }
 
 /************************************************************************/
@@ -310,13 +325,14 @@ uint32_t Adafruit_TSL2591::getFullLuminosity (void)
     }
   }
 
-  // Enable the device
-  enable();
-
-  // Wait x ms for ADC to complete
-  for (uint8_t d=0; d<=_integration; d++)
-  {
-    delay(120);
+  boolean was_enabled = _enabled;
+  if (!_enabled) {
+    enable();
+    // Wait x ms for ADC to complete
+    for (uint8_t d=0; d<=_integration; d++)
+    {
+      delay(120);
+    }
   }
 
   // CHAN0 must be read before CHAN1
@@ -328,7 +344,9 @@ uint32_t Adafruit_TSL2591::getFullLuminosity (void)
   x <<= 16;
   x |= y;
 
-  disable();
+  if (!was_enabled) {
+    disable();
+  }
 
   return x;
 }
@@ -380,13 +398,18 @@ void Adafruit_TSL2591::registerInterrupt(uint16_t lowerThreshold, uint16_t upper
     }
   }
 
-  enable();
+  boolean was_enabled = _enabled;
+  if (!_enabled) {
+    enable();
+  }
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_PERSIST_FILTER,  persist);
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_THRESHOLD_AILTL, lowerThreshold);
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_THRESHOLD_AILTH, lowerThreshold >> 8);
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_THRESHOLD_AIHTL, upperThreshold);
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_THRESHOLD_AIHTH, upperThreshold >> 8);
-  disable();
+  if (!was_enabled) {
+    disable();
+  }
 }
 
 /************************************************************************/
@@ -402,9 +425,14 @@ void Adafruit_TSL2591::clearInterrupt()
     }
   }
 
-  enable();
+  boolean was_enabled = _enabled;
+  if (!_enabled) {
+    enable();
+  }
   write8(TSL2591_CLEAR_INT);
-  disable();
+  if (!was_enabled) {
+    disable();
+  }
 }
 
 
@@ -423,10 +451,15 @@ uint8_t Adafruit_TSL2591::getStatus(void)
   }
 
   // Enable the device
-  enable();
+  boolean was_enabled = _enabled;
+  if (!_enabled) {
+    enable();
+  }
   uint8_t x;
   x = read8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_DEVICE_STATUS);
-  disable();
+  if (!was_enabled) {
+    disable();
+  }
   return x;
 }
 

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -166,6 +166,7 @@ class Adafruit_TSL2591 : public Adafruit_Sensor
   tsl2591Gain_t _gain;
   int32_t _sensorID;
 
+  boolean _enabled;
   boolean _initialized;
 };
 #endif

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -1,17 +1,17 @@
 /**************************************************************************/
-/*! 
+/*!
     @file     Adafruit_TSL2591.h
     @author   KT0WN (adafruit.com)
 
     This is a library for the Adafruit TSL2591 breakout board
-    This library works with the Adafruit TSL2591 breakout 
+    This library works with the Adafruit TSL2591 breakout
     ----> https://www.adafruit.com/products/1980
-	
-    Check out the links above for our tutorials and wiring diagrams 
+
+    Check out the links above for our tutorials and wiring diagrams
     These chips use I2C to communicate
- 
-    Adafruit invests time and resources providing this open source code, 
-    please support Adafruit and open-source hardware by purchasing 
+
+    Adafruit invests time and resources providing this open source code,
+    please support Adafruit and open-source hardware by purchasing
     products from Adafruit!
 */
 /**************************************************************************/
@@ -51,7 +51,7 @@
 #define TSL2591_ENABLE_NPIEN      (0x80)    ///< No Persist Interrupt Enable. When asserted NP Threshold conditions will generate an interrupt, bypassing the persist filter
 
 #define TSL2591_LUX_DF            (408.0F) ///< Lux cooefficient
-#define TSL2591_LUX_COEFB         (1.64F)  ///< CH0 coefficient 
+#define TSL2591_LUX_COEFB         (1.64F)  ///< CH0 coefficient
 #define TSL2591_LUX_COEFC         (0.59F)  ///< CH1 coefficient A
 #define TSL2591_LUX_COEFD         (0.86F)  ///< CH2 coefficient B
 
@@ -125,7 +125,7 @@ tsl2591Gain_t;
 
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Class that stores state and functions for interacting with TSL2591 Light Sensor
 */
 /**************************************************************************/
@@ -133,7 +133,7 @@ class Adafruit_TSL2591 : public Adafruit_Sensor
 {
  public:
   Adafruit_TSL2591(int32_t sensorID = -1);
-  
+
   boolean   begin   ( void );
   void      enable  ( void );
   void      disable ( void );
@@ -151,8 +151,8 @@ class Adafruit_TSL2591 : public Adafruit_Sensor
   void    clearInterrupt(void);
   void    registerInterrupt(uint16_t lowerThreshold, uint16_t upperThreshold, tsl2591Persist_t persist);
   uint8_t getStatus();
-  
-  /* Unified Sensor API Functions */  
+
+  /* Unified Sensor API Functions */
   bool getEvent  ( sensors_event_t* );
   void getSensor ( sensor_t* );
 

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -50,6 +50,10 @@
 #define TSL2591_ENABLE_AIEN       (0x10)    ///< ALS Interrupt Enable. When asserted permits ALS interrupts to be generated, subject to the persist filter.
 #define TSL2591_ENABLE_NPIEN      (0x80)    ///< No Persist Interrupt Enable. When asserted NP Threshold conditions will generate an interrupt, bypassing the persist filter
 
+#define TSL2591_STATUS_AVALID     (0b00000001) ///< Flag AVALID in STATUS register
+#define TSL2591_STATUS_AINT       (0b00010000) ///< Flag AINT in STATUS register
+#define TSL2591_STATUS_NPINTR     (0b00100000) ///< Flag NPINTR in STATUS register
+
 #define TSL2591_LUX_DF            (408.0F) ///< Lux cooefficient
 #define TSL2591_LUX_COEFB         (1.64F)  ///< CH0 coefficient
 #define TSL2591_LUX_COEFC         (0.59F)  ///< CH1 coefficient A

--- a/examples/tsl2591/tsl2591.ino
+++ b/examples/tsl2591/tsl2591.ino
@@ -31,7 +31,7 @@ void displaySensorDetails(void)
   Serial.print  (F("Unique ID:    ")); Serial.println(sensor.sensor_id);
   Serial.print  (F("Max Value:    ")); Serial.print(sensor.max_value); Serial.println(F(" lux"));
   Serial.print  (F("Min Value:    ")); Serial.print(sensor.min_value); Serial.println(F(" lux"));
-  Serial.print  (F("Resolution:   ")); Serial.print(sensor.resolution, 4); Serial.println(F(" lux"));  
+  Serial.print  (F("Resolution:   ")); Serial.print(sensor.resolution, 4); Serial.println(F(" lux"));
   Serial.println(F("------------------------------------"));
   Serial.println(F(""));
   delay(500);
@@ -48,7 +48,7 @@ void configureSensor(void)
   //tsl.setGain(TSL2591_GAIN_LOW);    // 1x gain (bright light)
   tsl.setGain(TSL2591_GAIN_MED);      // 25x gain
   //tsl.setGain(TSL2591_GAIN_HIGH);   // 428x gain
-  
+
   // Changing the integration time gives you a longer time over which to sense light
   // longer timelines are slower, but are good in very low light situtations!
   //tsl.setTiming(TSL2591_INTEGRATIONTIME_100MS);  // shortest integration time (bright light)
@@ -58,7 +58,7 @@ void configureSensor(void)
   // tsl.setTiming(TSL2591_INTEGRATIONTIME_500MS);
   // tsl.setTiming(TSL2591_INTEGRATIONTIME_600MS);  // longest integration time (dim light)
 
-  /* Display the gain and integration time for reference sake */  
+  /* Display the gain and integration time for reference sake */
   Serial.println(F("------------------------------------"));
   Serial.print  (F("Gain:         "));
   tsl2591Gain_t gain = tsl.getGain();
@@ -78,7 +78,7 @@ void configureSensor(void)
       break;
   }
   Serial.print  (F("Timing:       "));
-  Serial.print((tsl.getTiming() + 1) * 100, DEC); 
+  Serial.print((tsl.getTiming() + 1) * 100, DEC);
   Serial.println(F(" ms"));
   Serial.println(F("------------------------------------"));
   Serial.println(F(""));
@@ -90,25 +90,25 @@ void configureSensor(void)
     Program entry point for the Arduino sketch
 */
 /**************************************************************************/
-void setup(void) 
+void setup(void)
 {
   Serial.begin(9600);
-  
+
   Serial.println(F("Starting Adafruit TSL2591 Test!"));
-  
-  if (tsl.begin()) 
+
+  if (tsl.begin())
   {
     Serial.println(F("Found a TSL2591 sensor"));
-  } 
-  else 
+  }
+  else
   {
     Serial.println(F("No sensor found ... check your wiring?"));
     while (1);
   }
-    
+
   /* Display some basic information on this sensor */
   displaySensorDetails();
-  
+
   /* Configure the sensor */
   configureSensor();
 
@@ -123,7 +123,7 @@ void setup(void)
 /**************************************************************************/
 void simpleRead(void)
 {
-  // Simple data read example. Just read the infrared, fullspecrtrum diode 
+  // Simple data read example. Just read the infrared, fullspecrtrum diode
   // or 'visible' (difference between the two) channels.
   // This can take 100-600 milliseconds! Uncomment whichever of the following you want to read
   uint16_t x = tsl.getLuminosity(TSL2591_VISIBLE);
@@ -162,14 +162,14 @@ void advancedRead(void)
 /**************************************************************************/
 void unifiedSensorAPIRead(void)
 {
-  /* Get a new sensor event */ 
+  /* Get a new sensor event */
   sensors_event_t event;
   tsl.getEvent(&event);
- 
+
   /* Display the results (light is measured in lux) */
   Serial.print(F("[ ")); Serial.print(event.timestamp); Serial.print(F(" ms ] "));
   if ((event.light == 0) |
-      (event.light > 4294966000.0) | 
+      (event.light > 4294966000.0) |
       (event.light <-4294966000.0))
   {
     /* If event.light = 0 lux the sensor is probably saturated */
@@ -190,11 +190,11 @@ void unifiedSensorAPIRead(void)
     should go here)
 */
 /**************************************************************************/
-void loop(void) 
-{ 
-  //simpleRead(); 
+void loop(void)
+{
+  //simpleRead();
   advancedRead();
   // unifiedSensorAPIRead();
-  
+
   delay(500);
 }

--- a/examples/tsl2591/tsl2591.ino
+++ b/examples/tsl2591/tsl2591.ino
@@ -157,9 +157,10 @@ void advancedRead(void)
   last_action = millis();
   Serial.print(F("[ "));
     Serial.print(millis());
-    Serial.print(F(" ms -> "));
+    Serial.print(F(" ms ]"));
+    Serial.print(F(" ("));
     Serial.print(duration);
-    Serial.print(F(" ms ] "));
+    Serial.print(F(" ms) "));
   Serial.print(F("IR: ")); Serial.print(ir);  Serial.print(F("  "));
   Serial.print(F("Full: ")); Serial.print(full); Serial.print(F("  "));
   Serial.print(F("Visible: ")); Serial.print(full - ir); Serial.print(F("  "));

--- a/examples/tsl2591/tsl2591.ino
+++ b/examples/tsl2591/tsl2591.ino
@@ -99,7 +99,7 @@ void setup(void)
   if (tsl.begin())
   {
     Serial.println(F("Found a TSL2591 sensor"));
-    // if you want faster responses enable the sensor continously:
+    // if you want faster responses enable the sensor continuously:
     // (this needs more power..)
     tsl.enable();
   }

--- a/examples/tsl2591/tsl2591.ino
+++ b/examples/tsl2591/tsl2591.ino
@@ -99,6 +99,9 @@ void setup(void)
   if (tsl.begin())
   {
     Serial.println(F("Found a TSL2591 sensor"));
+    // if you want faster responses enable the sensor continously:
+    // (this needs more power..)
+    tsl.enable();
   }
   else
   {
@@ -140,6 +143,7 @@ void simpleRead(void)
     Show how to read IR and Full Spectrum at once and convert to lux
 */
 /**************************************************************************/
+uint32_t last_action = 0;
 void advancedRead(void)
 {
   // More advanced data read example. Read 32 bits with top 16 bits IR, bottom 16 bits full spectrum
@@ -148,7 +152,14 @@ void advancedRead(void)
   uint16_t ir, full;
   ir = lum >> 16;
   full = lum & 0xFFFF;
-  Serial.print(F("[ ")); Serial.print(millis()); Serial.print(F(" ms ] "));
+
+  uint32_t duration = millis() - last_action;
+  last_action = millis();
+  Serial.print(F("[ "));
+    Serial.print(millis());
+    Serial.print(F(" ms -> "));
+    Serial.print(duration);
+    Serial.print(F(" ms ] "));
   Serial.print(F("IR: ")); Serial.print(ir);  Serial.print(F("  "));
   Serial.print(F("Full: ")); Serial.print(full); Serial.print(F("  "));
   Serial.print(F("Visible: ")); Serial.print(full - ir); Serial.print(F("  "));

--- a/examples/tsl2591_interrupt/tsl2591_interrupt.ino
+++ b/examples/tsl2591_interrupt/tsl2591_interrupt.ino
@@ -4,35 +4,35 @@
 
 /*  This example shows how the interrupt system on the TLS2591
  *  can be used to detect a meaningful change in light levels.
- *  
- *  Two thresholds can be set: 
- *  
+ *
+ *  Two thresholds can be set:
+ *
  *  Lower Threshold - Any light sample on CHAN0 below this value
  *                    will trigger an interrupt
  *  Upper Threshold - Any light sample on CHAN0 above this value
  *                    will trigger an interrupt
- *                    
+ *
  *  If CHAN0 (full light) crosses below the low threshold specified,
  *  or above the higher threshold, an interrupt is asserted on the interrupt
  *  pin. The use of the HW pin is optional, though, since the change can
  *  also be detected in software by looking at the status byte via
  *  tsl.getStatus().
- *  
+ *
  *  An optional third parameter can be used in the .registerInterrupt
  *  function to indicate the number of samples that must stay outside
  *  the threshold window before the interrupt fires, providing some basic
  *  debouncing of light level data.
- *  
+ *
  *  For example, the following code will fire an interrupt on any and every
  *  sample outside the window threshold (meaning a sample below 100 or above
  *  1500 on CHAN0 or FULL light):
- *  
+ *
  *    tsl.registerInterrupt(100, 1500, TSL2591_PERSIST_ANY);
- *  
+ *
  *  This code would require five consecutive changes before the interrupt
  *  fires though (see tls2591Persist_t in Adafruit_TLS2591.h for possible
  *  values):
- *  
+ *
  *    tsl.registerInterrupt(100, 1500, TSL2591_PERSIST_5);
  */
 
@@ -134,7 +134,7 @@ void configureSensor(void)
   Serial.print("Interrupt Threshold Window: ");
   Serial.print(TLS2591_INT_THRESHOLD_LOWER, DEC);
   Serial.print(" to ");
-  Serial.println(TLS2591_INT_THRESHOLD_UPPER, DEC);  
+  Serial.println(TLS2591_INT_THRESHOLD_UPPER, DEC);
   Serial.println("");
 }
 

--- a/examples/tsl2591_interrupt_dev/tsl2591_interrupt_dev.ino
+++ b/examples/tsl2591_interrupt_dev/tsl2591_interrupt_dev.ino
@@ -1,0 +1,284 @@
+/* TSL2591 Digital Light Sensor, example with (simple) interrupt support  */
+/* Dynamic Range: 600M:1 */
+/* Maximum Lux: 88K */
+
+/*  This example shows how the interrupt system on the TLS2591
+*  can be used to detect a meaningful change in light levels.
+*
+*  Two thresholds can be set:
+*
+*  Lower Threshold - Any light sample on CHAN0 below this value
+*                    will trigger an interrupt
+*  Upper Threshold - Any light sample on CHAN0 above this value
+*                    will trigger an interrupt
+*
+*  If CHAN0 (full light) crosses below the low threshold specified,
+*  or above the higher threshold, an interrupt is asserted on the interrupt
+*  pin. The use of the HW pin is optional, though, since the change can
+*  also be detected in software by looking at the status byte via
+*  tsl.getStatus().
+*
+*  An optional third parameter can be used in the .registerInterrupt
+*  function to indicate the number of samples that must stay outside
+*  the threshold window before the interrupt fires, providing some basic
+*  debouncing of light level data.
+*
+*  For example, the following code will fire an interrupt on any and every
+*  sample outside the window threshold (meaning a sample below 100 or above
+*  2000 on CHAN0 or FULL light):
+*
+*    tsl.registerInterrupt(100, 2000, TSL2591_PERSIST_ANY);
+*
+*  This code would require five consecutive changes before the interrupt
+*  fires though (see tls2591Persist_t in Adafruit_TLS2591.h for possible
+*  values):
+*
+*    tsl.registerInterrupt(100, 2000, TSL2591_PERSIST_5);
+*/
+
+#include <Wire.h>
+#include <Adafruit_Sensor.h>
+#include "Adafruit_TSL2591.h"
+
+// Example for demonstrating the TSL2591 library - public domain!
+
+// connect SCL to I2C Clock
+// connect SDA to I2C Data
+// connect Vin to 3.3-5V DC
+// connect GROUND to common ground
+
+// Interrupt thresholds and persistance
+#define TLS2591_INT_THRESHOLD_LOWER  (100)
+#define TLS2591_INT_THRESHOLD_UPPER  (2000)
+//#define TLS2591_INT_PERSIST        (TSL2591_PERSIST_ANY) // Fire on any valid change
+#define TLS2591_INT_PERSIST          (TSL2591_PERSIST_10)  // Require at least 10 samples to fire
+
+Adafruit_TSL2591 tsl = Adafruit_TSL2591();
+
+
+
+
+
+void tsl_write8(uint8_t reg, uint8_t value) {
+    Wire.beginTransmission(TSL2591_ADDR);
+    Wire.write(reg);
+    Wire.write(value);
+    Wire.endTransmission();
+}
+
+
+/**************************************************************************/
+/*
+Displays some basic information on this sensor from the unified
+sensor API sensor_t type (see Adafruit_Sensor for more information)
+*/
+/**************************************************************************/
+void displaySensorDetails(void) {
+    sensor_t sensor;
+    tsl.getSensor(&sensor);
+    Serial.println("------------------------------------");
+    Serial.print  ("Sensor:       "); Serial.println(sensor.name);
+    Serial.print  ("Driver Ver:   "); Serial.println(sensor.version);
+    Serial.print  ("Unique ID:    "); Serial.println(sensor.sensor_id);
+    Serial.print  ("Max Value:    "); Serial.print(sensor.max_value); Serial.println(" lux");
+    Serial.print  ("Min Value:    "); Serial.print(sensor.min_value); Serial.println(" lux");
+    Serial.print  ("Resolution:   "); Serial.print(sensor.resolution, 4); Serial.println(" lux");
+    Serial.println("------------------------------------");
+    Serial.println("");
+    delay(500);
+}
+
+
+void tsl_print_gain(Print &out) {
+    tsl2591Gain_t gain = tsl.getGain();
+    switch (gain) {
+        case TSL2591_GAIN_LOW:
+        out.print(F("1x (Low)"));
+        break;
+        case TSL2591_GAIN_MED:
+        out.print(F("25x (Medium)"));
+        break;
+        case TSL2591_GAIN_HIGH:
+        out.print(F("428x (High)"));
+        break;
+        case TSL2591_GAIN_MAX:
+        out.print(F("9876x (Max)"));
+        break;
+    }
+}
+
+void tsl_print_timming(Print &out) {
+    out.print((tsl.getTiming() + 1) * 100, DEC);
+}
+
+/**************************************************************************/
+/*
+Configures the gain and integration time for the TSL2591
+*/
+/**************************************************************************/
+void configureSensor(void) {
+    // You can change the gain on the fly, to adapt to brighter/dimmer light situations
+    tsl.setGain(TSL2591_GAIN_LOW);    // 1x gain (bright light)
+    // tsl.setGain(TSL2591_GAIN_MED);      // 25x gain
+    // tsl.setGain(TSL2591_GAIN_HIGH);   // 428x gain
+
+    // Changing the integration time gives you a longer time over which to sense light
+    // longer timelines are slower, but are good in very low light situtations!
+    // tsl.setTiming(TSL2591_INTEGRATIONTIME_100MS);  // shortest integration time (bright light)
+    // tsl.setTiming(TSL2591_INTEGRATIONTIME_200MS);
+    // tsl.setTiming(TSL2591_INTEGRATIONTIME_300MS);
+    tsl.setTiming(TSL2591_INTEGRATIONTIME_400MS);
+    // tsl.setTiming(TSL2591_INTEGRATIONTIME_500MS);
+    // tsl.setTiming(TSL2591_INTEGRATIONTIME_600MS);  // longest integration time (dim light)
+
+    /* Display the gain and integration time for reference sake */
+    Serial.println("------------------------------------");
+    Serial.print  ("Gain:         ");
+    tsl2591Gain_t gain = tsl.getGain();
+    tsl_print_gain(Serial);
+    Serial.println();
+    Serial.print  ("Timing:       ");
+    tsl_print_timming(Serial);
+    Serial.println(" ms");
+    Serial.println("------------------------------------");
+    Serial.println("");
+
+    /* Setup the SW interrupt to trigger between 100 and 2000 */
+    /* Threshold values are defined at the top of this sketch */
+    tsl.clearInterrupt();
+    // tsl.registerInterrupt(TLS2591_INT_THRESHOLD_LOWER,
+    //     TLS2591_INT_THRESHOLD_UPPER,
+    //     TLS2591_INT_PERSIST);
+
+    /* Display the interrupt threshold window */
+    Serial.print("Interrupt Threshold Window: ");
+    Serial.print(TLS2591_INT_THRESHOLD_LOWER, DEC);
+    Serial.print(" to ");
+    Serial.println(TLS2591_INT_THRESHOLD_UPPER, DEC);
+    Serial.println("");
+}
+
+
+/**************************************************************************/
+/*
+Program entry point for the Arduino sketch
+*/
+/**************************************************************************/
+void setup(void) {
+    // Waits for the serial port to connect before sending data out
+    // wait for arduino IDE to release all serial ports after upload.
+    delay(1000);
+    // initialise serial
+    Serial.begin(115200);
+    // Wait for Serial Connection to be Opend from Host
+    // or timeout after 2seconds
+    uint32_t timeStamp_Start = millis();
+    while( (! Serial) && ( (millis() - timeStamp_Start) < 2000 ) ) {
+        // nothing to do
+    }
+
+    Serial.println("tsl2591_interrupt_dev.ino");
+
+    if (tsl.begin()) {
+        Serial.println("Found a TSL2591 sensor");
+        // enable sensor continuously
+        // otherwise the interrupt will not work.
+        tsl.enable();
+    } else {
+        Serial.println("No sensor found ... check your wiring?");
+        while (1) {}
+    }
+
+    /* Display some basic information on this sensor */
+    displaySensorDetails();
+
+    /* Configure the sensor (including the interrupt threshold) */
+    configureSensor();
+
+    // Now we're ready to get readings ... move on to loop()!
+}
+
+/**************************************************************************/
+/*
+Show how to read IR and Full Spectrum at once and convert to lux
+*/
+/**************************************************************************/
+uint32_t last_action = 0;
+void printStatus(void) {
+    uint32_t duration = millis() - last_action;
+    last_action = millis();
+    Serial.print(F("[ "));
+    Serial.print(millis());
+    Serial.print(F(" ms ]"));
+    Serial.print(F(" ("));
+    Serial.print(duration);
+    Serial.print(F(" ms) "));
+
+    uint8_t x = tsl.getStatus();
+
+    // Serial.print("status: '");
+    // Serial.print(x, HEX);
+    // Serial.print("  ");
+    Serial.print("'");
+    // for (size_t i = 0; i < 8; i++) {
+    //     if (bitRead(x, 7-i)) {
+    for (size_t i = 8; i > 0; i--) {
+        if (bitRead(x, i-1)) {
+            Serial.print("1");
+        } else {
+            Serial.print("0");
+        }
+    }
+    Serial.print("' ");
+
+    // print flags
+    // bit 0: AVALID = ALS Valid
+    // bit 4: AINT = ALS Interrupt occured
+    // bit 5: NPINTR = No-persist Interrupt occurence
+    if (x & TSL2591_STATUS_AVALID) {
+        Serial.print("AVALID");
+    } else {
+        Serial.print("  .   ");
+    }
+    Serial.print(" ");
+    if (x & TSL2591_STATUS_AINT) {
+        Serial.print("AINT");
+    } else {
+        Serial.print(" .  ");
+    }
+    Serial.print(" ");
+    if (x & TSL2591_STATUS_NPINTR) {
+        Serial.print("NPINTR");
+    } else {
+        Serial.print("  .   ");
+    }
+    Serial.print("  ");
+
+    // More advanced data read example. Read 32 bits with top 16 bits IR, bottom 16 bits full spectrum
+    // That way you can do whatever math and comparisons you want!
+    uint32_t lum = tsl.getFullLuminosity();
+    uint16_t ir, full;
+    ir = lum >> 16;
+    full = lum & 0xFFFF;
+
+    Serial.print("IR: "); Serial.print(ir);  Serial.print("  ");
+    Serial.print("Full: "); Serial.print(full); Serial.print("  ");
+    Serial.print("Visible: "); Serial.print(full - ir); Serial.print("  ");
+    Serial.print("Lux: "); Serial.print(tsl.calculateLux(full, ir));
+    // Serial.print("  ");
+    Serial.println();
+
+    tsl.clearInterrupt();
+}
+
+
+/**************************************************************************/
+/*
+Arduino loop function, called once 'setup' is complete (your own code
+should go here)
+*/
+/**************************************************************************/
+void loop(void) {
+    printStatus();
+    delay(90);
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit TSL2591 Library
-version=1.1.1
+version=1.2.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the TSL2591 digital luminosity (light) sensors.


### PR DESCRIPTION
let user decide if sensor should run continuously or only on interaction. 
(default: maintains old behavior = enable only on interaction)

so for the new 'continuously on mode' you have to enable it after the begin call:
```
if (tsl.begin()) {
    Serial.println(F("Found a TSL2591 sensor"));
    // if you want faster (non delaying) responses enable the sensor continuously:
    // (this needs more power..)
    tsl.enable();
}
```


should be fixing most things requested in #12
