### PR TITLE
Implement sensor reset via TSL2591_SRESET

### DIFF
--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -147,6 +147,11 @@ void Adafruit_TSL2591::disable(void)
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_ENABLE, TSL2591_ENABLE_POWEROFF);
 }
 
+/**************************************************************************/
+/*!
+    @brief Resets the chip via system reset command
+*/
+/**************************************************************************/
 void Adafruit_TSL2591::reset(void) {
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_CONTROL, TSL2591_SRESET);
   _initialized = false;

--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -147,6 +147,11 @@ void Adafruit_TSL2591::disable(void)
   write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_ENABLE, TSL2591_ENABLE_POWEROFF);
 }
 
+void Adafruit_TSL2591::reset(void) {
+  write8(TSL2591_COMMAND_BIT | TSL2591_REGISTER_CONTROL, TSL2591_SRESET);
+  _initialized = false;
+}
+
 /************************************************************************/
 /*!
     @brief  Setter for sensor light gain

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -55,6 +55,8 @@
 #define TSL2591_LUX_COEFC         (0.59F)  ///< CH1 coefficient A
 #define TSL2591_LUX_COEFD         (0.86F)  ///< CH2 coefficient B
 
+#define TSL2591_SRESET            (0x80)   ///< System reset
+
 /// TSL2591 Register map
 enum
 {
@@ -137,6 +139,7 @@ class Adafruit_TSL2591 : public Adafruit_Sensor
   boolean   begin   ( void );
   void      enable  ( void );
   void      disable ( void );
+  void      reset   ( void );
 
   float     calculateLux  ( uint16_t ch0, uint16_t ch1 );
   void      setGain       ( tsl2591Gain_t gain );


### PR DESCRIPTION
When my sensor gets disconnected from I2C and is reconnected shortly after then the reading is no longer valid. In this case (getStatus() would return 0xFF) calling the reset() function comes in handy.

The reset method writes TSL2591_SRESET to the control register (see https://cdn-shop.adafruit.com/datasheets/TSL25911_Datasheet_EN_v1.pdf, p.13).

I tested the change on an ESP32 using I2C: after disconnecting and reconnecting the readings return to normal as soon as my code calls the new reset() method.

I did not test SPI.

I'm aware that there might be better ways than resetting the sensor, but the function itself is not evil as far as I can tell.