### PR TITLE
manually set i2c adress

### DIFF
--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -53,13 +53,15 @@
     @brief  Instantiates a new Adafruit TSL2591 class
     @param  sensorID An optional ID # so you can track this sensor, it will tag
    sensorEvents you create.
+    @param  addr The I2C adress of the sensor (Default 0x29)
 */
 /**************************************************************************/
-Adafruit_TSL2591::Adafruit_TSL2591(int32_t sensorID) {
+Adafruit_TSL2591::Adafruit_TSL2591(int32_t sensorID, uint8_t addr) {
   _initialized = false;
   _integration = TSL2591_INTEGRATIONTIME_100MS;
   _gain = TSL2591_GAIN_MED;
   _sensorID = sensorID;
+  _addr = addr;
 
   // we cant do wire initialization till later, because we havent loaded Wire
   // yet
@@ -480,11 +482,11 @@ void Adafruit_TSL2591::getSensor(sensor_t *sensor) {
 uint8_t Adafruit_TSL2591::read8(uint8_t reg) {
   uint8_t x;
 
-  _i2c->beginTransmission(TSL2591_ADDR);
+  _i2c->beginTransmission(_addr);
   _i2c->write(reg);
   _i2c->endTransmission();
 
-  _i2c->requestFrom(TSL2591_ADDR, 1);
+  _i2c->requestFrom(_addr, 1);
   x = _i2c->read();
 
   return x;
@@ -494,11 +496,11 @@ uint16_t Adafruit_TSL2591::read16(uint8_t reg) {
   uint16_t x;
   uint16_t t;
 
-  _i2c->beginTransmission(TSL2591_ADDR);
+  _i2c->beginTransmission(_addr);
   _i2c->write(reg);
   _i2c->endTransmission();
 
-  _i2c->requestFrom(TSL2591_ADDR, 2);
+  _i2c->requestFrom(_addr, 2);
   t = _i2c->read();
   x = _i2c->read();
 
@@ -508,14 +510,14 @@ uint16_t Adafruit_TSL2591::read16(uint8_t reg) {
 }
 
 void Adafruit_TSL2591::write8(uint8_t reg, uint8_t value) {
-  _i2c->beginTransmission(TSL2591_ADDR);
+  _i2c->beginTransmission(_addr);
   _i2c->write(reg);
   _i2c->write(value);
   _i2c->endTransmission();
 }
 
 void Adafruit_TSL2591::write8(uint8_t reg) {
-  _i2c->beginTransmission(TSL2591_ADDR);
+  _i2c->beginTransmission(_addr);
   _i2c->write(reg);
   _i2c->endTransmission();
 }

--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -53,15 +53,13 @@
     @brief  Instantiates a new Adafruit TSL2591 class
     @param  sensorID An optional ID # so you can track this sensor, it will tag
    sensorEvents you create.
-    @param  addr The I2C adress of the sensor (Default 0x29)
 */
 /**************************************************************************/
-Adafruit_TSL2591::Adafruit_TSL2591(int32_t sensorID, uint8_t addr) {
+Adafruit_TSL2591::Adafruit_TSL2591(int32_t sensorID) {
   _initialized = false;
   _integration = TSL2591_INTEGRATIONTIME_100MS;
   _gain = TSL2591_GAIN_MED;
   _sensorID = sensorID;
-  _addr = addr;
 
   // we cant do wire initialization till later, because we havent loaded Wire
   // yet
@@ -71,12 +69,14 @@ Adafruit_TSL2591::Adafruit_TSL2591(int32_t sensorID, uint8_t addr) {
 /*!
     @brief  Setups the I2C interface and hardware, identifies if chip is found
     @param theWire a reference to TwoWire instance
+    @param  addr The I2C adress of the sensor (Default 0x29)
     @returns True if a TSL2591 is found, false on any failure
 */
 /**************************************************************************/
-boolean Adafruit_TSL2591::begin(TwoWire *theWire) {
+boolean Adafruit_TSL2591::begin(TwoWire *theWire, uint8_t addr) {
   _i2c = theWire;
   _i2c->begin();
+  _addr = addr;
 
   /*
   for (uint8_t i=0; i<0x20; i++)
@@ -107,12 +107,14 @@ boolean Adafruit_TSL2591::begin(TwoWire *theWire) {
 /**************************************************************************/
 /*!
     @brief  Setups the I2C interface and hardware, identifies if chip is found
+    @param  addr The I2C adress of the sensor (Default 0x29)
     @returns True if a TSL2591 is found, false on any failure
 */
 /**************************************************************************/
-boolean Adafruit_TSL2591::begin() {
+boolean Adafruit_TSL2591::begin(uint8_t addr) {
 
   begin(&Wire);
+  _addr = addr;
 
   return true;
 }

--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -67,13 +67,13 @@ Adafruit_TSL2591::Adafruit_TSL2591(int32_t sensorID) {
 
 /**************************************************************************/
 /*!
-    @brief  Setups the I2C interface and hardware, identifies if chip is found
-    @param theWire a reference to TwoWire instance
-    @param  addr The I2C adress of the sensor (Default 0x29)
+    @brief   Setups the I2C interface and hardware, identifies if chip is found
+    @param   addr The I2C adress of the sensor (Default 0x29)
+    @param   theWire a reference to TwoWire instance
     @returns True if a TSL2591 is found, false on any failure
 */
 /**************************************************************************/
-boolean Adafruit_TSL2591::begin(TwoWire *theWire, uint8_t addr) {
+boolean Adafruit_TSL2591::begin(uint8_t addr, TwoWire *theWire) {
   _i2c = theWire;
   _i2c->begin();
   _addr = addr;
@@ -106,8 +106,8 @@ boolean Adafruit_TSL2591::begin(TwoWire *theWire, uint8_t addr) {
 }
 /**************************************************************************/
 /*!
-    @brief  Setups the I2C interface and hardware, identifies if chip is found
-    @param  addr The I2C adress of the sensor (Default 0x29)
+    @brief   Setups the I2C interface and hardware, identifies if chip is found
+    @param   addr The I2C adress of the sensor (Default 0x29)
     @returns True if a TSL2591 is found, false on any failure
 */
 /**************************************************************************/

--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -68,12 +68,12 @@ Adafruit_TSL2591::Adafruit_TSL2591(int32_t sensorID) {
 /**************************************************************************/
 /*!
     @brief   Setups the I2C interface and hardware, identifies if chip is found
-    @param   addr The I2C adress of the sensor (Default 0x29)
     @param   theWire a reference to TwoWire instance
+    @param   addr The I2C adress of the sensor (Default 0x29)
     @returns True if a TSL2591 is found, false on any failure
 */
 /**************************************************************************/
-boolean Adafruit_TSL2591::begin(uint8_t addr, TwoWire *theWire) {
+boolean Adafruit_TSL2591::begin(TwoWire *theWire, uint8_t addr) {
   _i2c = theWire;
   _i2c->begin();
   _addr = addr;

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -130,7 +130,7 @@ typedef enum {
 /**************************************************************************/
 class Adafruit_TSL2591 : public Adafruit_Sensor {
 public:
-  Adafruit_TSL2591(int32_t sensorID = -1);
+  Adafruit_TSL2591(int32_t sensorID = -1, uint8_t addr = TSL2591_ADDR);
 
   boolean begin(TwoWire *theWire);
   boolean begin();
@@ -167,6 +167,7 @@ private:
   tsl2591IntegrationTime_t _integration;
   tsl2591Gain_t _gain;
   int32_t _sensorID;
+  uint8_t addr;
 
   boolean _initialized;
 };

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -132,7 +132,7 @@ class Adafruit_TSL2591 : public Adafruit_Sensor {
 public:
   Adafruit_TSL2591(int32_t sensorID = -1);
 
-  boolean begin(TwoWire *theWire, uint8_t addr = TSL2591_ADDR);
+  boolean begin(uint8_t addr = TSL2591_ADDR, TwoWire *theWire);
   boolean begin(uint8_t addr = TSL2591_ADDR);
   void enable(void);
   void disable(void);

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -167,7 +167,7 @@ private:
   tsl2591IntegrationTime_t _integration;
   tsl2591Gain_t _gain;
   int32_t _sensorID;
-  uint8_t addr;
+  uint8_t _addr;
 
   boolean _initialized;
 };

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -132,7 +132,7 @@ class Adafruit_TSL2591 : public Adafruit_Sensor {
 public:
   Adafruit_TSL2591(int32_t sensorID = -1);
 
-  boolean begin(uint8_t addr = TSL2591_ADDR, TwoWire *theWire);
+  boolean begin(TwoWire *theWire, uint8_t addr = TSL2591_ADDR);
   boolean begin(uint8_t addr = TSL2591_ADDR);
   void enable(void);
   void disable(void);

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -130,10 +130,10 @@ typedef enum {
 /**************************************************************************/
 class Adafruit_TSL2591 : public Adafruit_Sensor {
 public:
-  Adafruit_TSL2591(int32_t sensorID = -1, uint8_t addr = TSL2591_ADDR);
+  Adafruit_TSL2591(int32_t sensorID = -1);
 
-  boolean begin(TwoWire *theWire);
-  boolean begin();
+  boolean begin(TwoWire *theWire, uint8_t addr = TSL2591_ADDR);
+  boolean begin(uint8_t addr = TSL2591_ADDR);
   void enable(void);
   void disable(void);
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Adafruit TSL2591 Library [![Build Status](https://travis-ci.com/adafruit/Adafruit_TSL2591_Library.svg?branch=master)](https://travis-ci.com/adafruit/Adafruit_TSL2591_Library)
 
-<img src="https://cdn-shop.adafruit.com/970x728/1980-01.jpg" height="300"/>
+<img src="https://cdn-shop.adafruit.com/970x728/1980-07.jpg" height="300"/>
 
 This is an Arduino library for the TSL2591 digital luminosity (light) sensors. 
 


### PR DESCRIPTION
The scope of the change is to be able to manually set the i2c adress of the sensor. Since you're able to change the i2c adress with jumpers on some version of this board, it is necessary to be also able to change the adress within the code. If no adress is set and the libary is handled the same as before, the change has no impact.

The code has no known limitations.

The code worked fine on tests.