### PR TITLE
lowlight bugfix in getLuminosity(TSL2591_VISIBLE) when there are low …

### DIFF
--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -227,6 +227,12 @@ float Adafruit_TSL2591::calculateLux(uint16_t ch0, uint16_t ch1) {
     return -1;
   }
 
+  // Check if IR < FULL and IR != 0 to prevent divisions by zero or negative
+  // lux values
+  if ((ch0 == 0) || (ch0 < ch1)) {
+    return 0;
+  }
+
   // Note: This algorithm is based on preliminary coefficients
   // provided by AMS and may need to be updated in the future
 

--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -356,7 +356,7 @@ uint16_t Adafruit_TSL2591::getLuminosity(uint8_t channel) {
       return ((x & 0xFFFF) - (x >> 16));
     } else {
       return 0;
-    }    
+    }
   }
 
   // unknown channel!

--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -344,7 +344,13 @@ uint16_t Adafruit_TSL2591::getLuminosity(uint8_t channel) {
     return (x >> 16);
   } else if (channel == TSL2591_VISIBLE) {
     // Reads all and subtracts out just the visible!
-    return ((x & 0xFFFF) - (x >> 16));
+    // Checks, if the CH1 value is smaller than the CH2 value in order to
+    // prevent an uint overflow
+    if ((x >> 16) < (x & 0xFFFF)) {
+      return ((x & 0xFFFF) - (x >> 16));
+    } else {
+      return 0;
+    }    
   }
 
   // unknown channel!

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit TSL2591 Library
-version=1.2.1
+version=1.2.2
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the TSL2591 digital luminosity (light) sensors.


### PR DESCRIPTION
in low light situations, it is possible, that the ir photodiode returns a higher value than the fullspectrum photodiode. if that happens, the calculated result was a low negative number which results in a high positive number if returned as an uint.

e.g. if the fullspec diode returns 0 and the ir diode returns 1, the calculated result for the visible value was -1. if -1 is stored in an uint16_t it results as an 0xFFFE.

**The Scope** of the change is to prevent the getLuminosity(TSL2591_VISIBLE) method to return 0xFFFF or 0xFFFE in low light situations, when the IR diode can return values greater then the ones from the fullspec diode.

 **Describe any known limitations with your change.**  There are no known limitations.

- **Please run any tests or examples that can exercise your modified code.**  The code is running fine within an installation of the tsl2591

