### PR TITLE
[#38] Makes begin() return status

### DIFF
--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -111,9 +111,7 @@ boolean Adafruit_TSL2591::begin(TwoWire *theWire, uint8_t addr) {
     @returns True if a TSL2591 is found, false on any failure
 */
 /**************************************************************************/
-boolean Adafruit_TSL2591::begin(uint8_t addr) {
-  return begin(&Wire, addr);
-}
+boolean Adafruit_TSL2591::begin(uint8_t addr) { return begin(&Wire, addr); }
 
 /**************************************************************************/
 /*!

--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -112,11 +112,7 @@ boolean Adafruit_TSL2591::begin(TwoWire *theWire, uint8_t addr) {
 */
 /**************************************************************************/
 boolean Adafruit_TSL2591::begin(uint8_t addr) {
-
-  begin(&Wire);
-  _addr = addr;
-
-  return true;
+  return begin(&Wire, addr);
 }
 
 /**************************************************************************/


### PR DESCRIPTION
Fixes Adafruit_TSL2591::begin(uint8_t) always returning true.
