### PR TITLE
Fix possible division by zero

### DIFF
--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -276,7 +276,7 @@ float Adafruit_TSL2591::calculateLux(uint16_t ch0, uint16_t ch1) {
 
   // Alternate lux calculation 1
   // See: https://github.com/adafruit/Adafruit_TSL2591_Library/issues/14
-  lux = (((float)ch0 - (float)ch1)) * (1.0F - ((float)ch1 / (float)ch0)) / cpl;
+  lux = (((float)ch0 - (float)ch1)) * (1.0F - ((float)ch1 / (float)((ch0 != 0) ? ch0 : 1.0F))) / cpl;
 
   // Alternate lux calculation 2
   // lux = ( (float)ch0 - ( 1.7F * (float)ch1 ) ) / cpl;


### PR DESCRIPTION
Adafruit_TSL2591::calculateLux function: 
It's dangerous in case ch0 is 0!
In case it is 0 use the next greater number 1 for the formula, which should least falsify the calculated result.