### PR TITLE
Tweak memory alloc and cleanup

### DIFF
--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -65,6 +65,11 @@ Adafruit_TSL2591::Adafruit_TSL2591(int32_t sensorID) {
   // yet
 }
 
+Adafruit_TSL2591::~Adafruit_TSL2591() {
+  if (i2c_dev)
+    delete i2c_dev;
+}
+
 /**************************************************************************/
 /*!
     @brief   Setups the I2C interface and hardware, identifies if chip is found
@@ -74,6 +79,8 @@ Adafruit_TSL2591::Adafruit_TSL2591(int32_t sensorID) {
 */
 /**************************************************************************/
 boolean Adafruit_TSL2591::begin(TwoWire *theWire, uint8_t addr) {
+  if (i2c_dev)
+    delete i2c_dev;
   i2c_dev = new Adafruit_I2CDevice(addr, theWire);
   if (!i2c_dev->begin())
     return false;

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -131,6 +131,7 @@ typedef enum {
 class Adafruit_TSL2591 : public Adafruit_Sensor {
 public:
   Adafruit_TSL2591(int32_t sensorID = -1);
+  ~Adafruit_TSL2591();
 
   boolean begin(TwoWire *theWire, uint8_t addr = TSL2591_ADDR);
   boolean begin(uint8_t addr = TSL2591_ADDR);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit TSL2591 Library
-version=1.4.0
+version=1.4.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the TSL2591 digital luminosity (light) sensors.


### PR DESCRIPTION
Tested with Qt PY.

```cpp
#include "Adafruit_TSL2591.h"

Adafruit_TSL2591 tsl = Adafruit_TSL2591(2591); 

void setup(void) 
{
  Serial.begin(9600);
  while(!Serial);
  
  Serial.println(F("Starting Adafruit TSL2591 multi begin() Test!"));
}

void loop(void) 
{ 
  if (!tsl.begin()) {
    Serial.println(F("No sensor found ... check your wiring?"));
    while (1);
  } 

  uint16_t x = tsl.getLuminosity(TSL2591_VISIBLE);

  Serial.print(F("[ ")); Serial.print(millis()); Serial.print(F(" ms ] "));
  Serial.print(F("Luminosity: "));
  Serial.println(x, DEC);
  
  delay(1000);
}
```

![Screenshot from 2021-08-24 12-48-33](https://user-images.githubusercontent.com/8755041/130680615-6f7bafe1-6b97-488a-8ea3-af0c25a4c854.png)
