### PR TITLE
Move read16 to public

### DIFF
--- a/Adafruit_TSL2591.cpp
+++ b/Adafruit_TSL2591.cpp
@@ -488,6 +488,13 @@ uint8_t Adafruit_TSL2591::read8(uint8_t reg) {
   return buffer[0];
 }
 
+/************************************************************************/
+/*!
+    @brief  Reads a 16-bit value from the specified register on the sensor
+    @param  reg The register address to read from
+    @return The 16-bit value read from the specified register
+*/
+/**************************************************************************/
 uint16_t Adafruit_TSL2591::read16(uint8_t reg) {
   uint8_t buffer[2];
   buffer[0] = reg;

--- a/Adafruit_TSL2591.h
+++ b/Adafruit_TSL2591.h
@@ -143,6 +143,7 @@ public:
   void setTiming(tsl2591IntegrationTime_t integration);
   uint16_t getLuminosity(uint8_t channel);
   uint32_t getFullLuminosity();
+  uint16_t read16(uint8_t reg);
 
   tsl2591IntegrationTime_t getTiming();
   tsl2591Gain_t getGain();
@@ -162,7 +163,6 @@ private:
 
   void write8(uint8_t r);
   void write8(uint8_t r, uint8_t v);
-  uint16_t read16(uint8_t reg);
   uint8_t read8(uint8_t reg);
 
   tsl2591IntegrationTime_t _integration;


### PR DESCRIPTION
This allows users to write custom `getFullLuminosity` implementations. All other properties are already available.

My use case was to write an alternative `getFullLuminosity`, that uses `vTaskDelay` instead of `delay` to avoid blocking the main `loop()` during reads.

This was really important to get the library to work reliably with OneButton, although other workarounds may exist for that in particular.

Here is what I implemented:

```cpp

// Sensor read variables.
uint32_t luminosity = 0;

void sensorTaskFreeRTOS(void *pvParameters) {
  while (1) {
      // Enable the sensor (draws power).
      tsl.enable();
      
      // Non-blocking delay to wait for the sensor read.
      for (uint8_t d = 0; d <= tsl.getTiming(); d++) {
        vTaskDelay(120 / portTICK_PERIOD_MS);
      }
      
      // The sensor should have produced data by now. Try reading it.
      uint16_t y = tsl.read16(TSL2591_COMMAND_BIT | TSL2591_REGISTER_CHAN0_LOW);
      uint32_t x = tsl.read16(TSL2591_COMMAND_BIT | TSL2591_REGISTER_CHAN1_LOW);

      // Make the full luminosity output value.
      x <<= 16;
      x |= y;
      
      // Disable for low power draw.
      tsl.disable();

      // Save the value.
      luminosity = x;
      Serial.printf("Luminosity: %lu\n", luminosity);
      
      // Delay briefly until the next read.
      vTaskDelay(100 / portTICK_PERIOD_MS);
  }
}
```